### PR TITLE
Display "pending" instead of "100%" for unfinished not-late promises

### DIFF
--- a/helpers/format.js
+++ b/helpers/format.js
@@ -23,8 +23,9 @@ Handlebars.registerHelper('verbifyDomain', function(opts) {
 })
 
 Handlebars.registerHelper('prettyCredit', function(credit) {
-  if (credit)
+  if (credit) {
     return Handlebars.helpers.prettyPercent(credit)
-  else
+  } else {
     return "pending"
+  }
 })

--- a/helpers/format.js
+++ b/helpers/format.js
@@ -23,8 +23,8 @@ Handlebars.registerHelper('verbifyDomain', function(opts) {
 })
 
 Handlebars.registerHelper('prettyCredit', function(credit) {
-  if (isNaN(credit))
-    return "pending"
-  else
+  if (credit)
     return Handlebars.helpers.prettyPercent(credit)
+  else
+    return "pending"
 })

--- a/helpers/format.js
+++ b/helpers/format.js
@@ -21,3 +21,10 @@ Handlebars.registerHelper('verbifyDomain', function(opts) {
   // console.log('verbifyDomain', domain)
   return domain && domain.replace('.to', ' to')
 })
+
+Handlebars.registerHelper('prettyCredit', function(credit) {
+  if (isNaN(credit))
+    return "pending"
+  else
+    return Handlebars.helpers.prettyPercent(credit)
+})

--- a/lib/parse/credit.js
+++ b/lib/parse/credit.js
@@ -6,7 +6,7 @@ import computeCredit from '../latepenalty'
 export default function parseCredit(args) {
   // unfinished, still in time promise
   if (! args.finishDate && Date.now() < args.dueDate)
-    return NaN
+    return null
 
   const cred = computeCredit(timeDiff(args))
   

--- a/lib/parse/credit.js
+++ b/lib/parse/credit.js
@@ -5,8 +5,9 @@ import computeCredit from '../latepenalty'
 
 export default function parseCredit(args) {
   // unfinished, still in time promise
-  if (! args.finishDate && Date.now() < args.dueDate)
+  if (! args.finishDate && Date.now() < args.dueDate) {
     return null
+  }
 
   const cred = computeCredit(timeDiff(args))
   

--- a/lib/parse/credit.js
+++ b/lib/parse/credit.js
@@ -4,6 +4,10 @@ import computeCredit from '../latepenalty'
 // TODO refactor/split this out
 
 export default function parseCredit(args) {
+  // unfinished, still in time promise
+  if (! args.finishDate && Date.now() < args.dueDate)
+    return NaN
+
   const cred = computeCredit(timeDiff(args))
   
   //console.log('parseCredit', args, cred)

--- a/models/promise.js
+++ b/models/promise.js
@@ -20,12 +20,11 @@ export default sequelize.define("promises", { // sequelize needs the doublequote
     type: Sequelize.VIRTUAL,
     get: function() {
       // TODO make parseCredit more robust
-      const cred = parseCredit({
+      const credit = parseCredit({
         dueDate: this.get('tdue'),
         finishDate: this.get('tfin')
       })
 
-      const credit = isNaN(cred) ? 1 : cred
       // console.log('virtual credit', credit)
       return credit
     }

--- a/views/partials/card.handlebars
+++ b/views/partials/card.handlebars
@@ -1,6 +1,6 @@
 <section class="promise-card {{#if promise.tfin}}completed{{/if}} {{dueColor (dueStatus promise.tdue)}}">
   <div class="promise-credit {{creditColor promise.credit}}">
-    {{prettyPercent promise.credit}}
+    {{prettyCredit promise.credit}}
   </div>
 
   <div class="promise-header">


### PR DESCRIPTION
This is my take at implementing the first part of #90. I'm basically new to all the technologies in your stack, so this might be horribly wrong, just let me know ;)

Regarding the expected behaviour, I think it's useful to show "pending" when the promise is still in the future, but the (decreasing) percentage if it is late. Let's discuss if you had something else in mind.